### PR TITLE
chore: bump go version to 1.25.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fachschaftinformatik/web
 
-go 1.25.1
+go 1.25.2
 
 tool (
 	github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen


### PR DESCRIPTION
See the [Go 1.25.2 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.25.2+label%3ACherryPickApproved) for details.